### PR TITLE
[May break compatibility] Mesh nx

### DIFF
--- a/examples/thermique1d/makefile
+++ b/examples/thermique1d/makefile
@@ -5,7 +5,7 @@ CC = g++
 # Adapt the following lines to your own system:
 PETSCDIR = /usr/lib/petscdir/3.4.2
 MPIDIR = /usr/lib/openmpi
-CDMATHDIR = ../..
+CDMATHDIR = ../../../../..
 
 IFLAG = -I$(PETSCDIR)/include -I$(MPIDIR)/include -I$(CDMATHDIR)/include -I.
 LFLAG = -L$(CDMATHDIR)/lib

--- a/examples/transport1d/makefile
+++ b/examples/transport1d/makefile
@@ -2,7 +2,7 @@
 
 CC = g++
 # Adapt the following line to your own system:
-CDMATHDIR = ../..
+CDMATHDIR = ../../../../..
 IFLAG = -I$(CDMATHDIR)/include -I.
 LFLAG = -L$(CDMATHDIR)/lib
 LIBS  =-linterpkernel -lmedC -lmedloader -lmedcoupling -lbase -lmesh -llinearsolver

--- a/examples/transport2d_ns/makefile
+++ b/examples/transport2d_ns/makefile
@@ -2,7 +2,7 @@
 
 CC = g++
 # Adapt the following line to your own system:
-CDMATHDIR = ../..
+CDMATHDIR = ../../../../..
 IFLAG = -I$(CDMATHDIR)/include -I.
 LFLAG = -L$(CDMATHDIR)/lib -L$(PETSC_DIR)/$(PETSC_ARCH)/lib
 LIBS  = -linterpkernel -lmedC -lmedloader -lmedcoupling -lbase -lmesh -llinearsolver -lpetsc

--- a/examples/transport2d_s/makefile
+++ b/examples/transport2d_s/makefile
@@ -2,8 +2,8 @@
 
 CC = g++
 # Adapt the following line to your own system:
-CDMATHDIR = ../..
-IFLAG = -I$(ICDMATHDIR)/include -I.
+CDMATHDIR = ../../../../..
+IFLAG = -I$(CDMATHDIR)/include -I.
 LFLAG = -L$(CDMATHDIR)/lib
 LIBS  =-linterpkernel -lmedC -lmedloader -lmedcoupling -lbase -lmesh -llinearsolver
 OBJ = main.o

--- a/mesh/src/Mesh.cxx
+++ b/mesh/src/Mesh.cxx
@@ -44,7 +44,6 @@ Mesh::Mesh( void )
     _zMin=0.;
     _zSup=0.;
     _groups.resize(0);
-	cout << "TTTTTTTT : " << _zSup << endl;
 }
 
 //----------------------------------------------------------------------
@@ -96,7 +95,6 @@ Mesh::Mesh( const ParaMEDMEM::MEDCouplingIMesh* mesh )
                                 originPtr+_dim,
                                 dxyzPtr,
                                 dxyzPtr+_dim);
-	cout << "TTTTTTTT : " << _mesh->getNumberOfCells() << endl;
     delete [] originPtr;
     delete [] dxyzPtr;
     delete [] nodeStrctPtr;

--- a/mesh/src/Mesh.cxx
+++ b/mesh/src/Mesh.cxx
@@ -63,6 +63,8 @@ Mesh::Mesh( const ParaMEDMEM::MEDCouplingIMesh* mesh )
     double* Box0=new double[2*_dim];
     mesh->getBoundingBox(Box0);
     _nxyz = nxyzMED;
+    for (int i=0; i<_dim; i++)
+		_nxyz[i]--;
 
     _xMin=Box0[0];
     _xSup=Box0[1];

--- a/mesh/src/Mesh.cxx
+++ b/mesh/src/Mesh.cxx
@@ -44,6 +44,7 @@ Mesh::Mesh( void )
     _zMin=0.;
     _zSup=0.;
     _groups.resize(0);
+	cout << "TTTTTTTT : " << _zSup << endl;
 }
 
 //----------------------------------------------------------------------
@@ -59,14 +60,9 @@ Mesh::Mesh( const ParaMEDMEM::MEDCouplingIMesh* mesh )
 {
     _dim=mesh->getSpaceDimension();
     vector<double> dxyz=mesh->getDXYZ();
-    vector<int> nxyzMED=mesh->getCellGridStructure();
+    _nxyz=mesh->getCellGridStructure();
     double* Box0=new double[2*_dim];
     mesh->getBoundingBox(Box0);
-    _nxyz = nxyzMED;
-    /*
-    for (int i=0; i<_dim; i++)
-		_nxyz[i]--;
-	*/
 
     _xMin=Box0[0];
     _xSup=Box0[1];
@@ -89,10 +85,9 @@ Mesh::Mesh( const ParaMEDMEM::MEDCouplingIMesh* mesh )
     for(int i=0;i<_dim;i++)
     {
         originPtr[i]=Box0[2*i];
-        nodeStrctPtr[i]=nxyzMED[i]+1;
+        nodeStrctPtr[i]=_nxyz[i]+1;
         dxyzPtr[i]=dxyz[i];
     }
-
     _mesh=MEDCouplingIMesh::New("MESH2D",
                                 _dim,
                                 nodeStrctPtr,
@@ -101,6 +96,7 @@ Mesh::Mesh( const ParaMEDMEM::MEDCouplingIMesh* mesh )
                                 originPtr+_dim,
                                 dxyzPtr,
                                 dxyzPtr+_dim);
+	cout << "TTTTTTTT : " << _mesh->getNumberOfCells() << endl;
     delete [] originPtr;
     delete [] dxyzPtr;
     delete [] nodeStrctPtr;

--- a/mesh/src/Mesh.cxx
+++ b/mesh/src/Mesh.cxx
@@ -89,7 +89,7 @@ Mesh::Mesh( const ParaMEDMEM::MEDCouplingIMesh* mesh )
     for(int i=0;i<_dim;i++)
     {
         originPtr[i]=Box0[2*i];
-        nodeStrctPtr[i]=nxyzMED[i];
+        nodeStrctPtr[i]=nxyzMED[i]+1;
         dxyzPtr[i]=dxyz[i];
     }
 

--- a/mesh/src/Mesh.cxx
+++ b/mesh/src/Mesh.cxx
@@ -2,7 +2,7 @@
  * mesh.cxx
  *
  *  Created on: 22 janv. 2012
- *      Authors: CDMAT
+ *      Authors: CDMATH
  */
 
 #include "Mesh.hxx"
@@ -59,12 +59,10 @@ Mesh::Mesh( const ParaMEDMEM::MEDCouplingIMesh* mesh )
 {
     _dim=mesh->getSpaceDimension();
     vector<double> dxyz=mesh->getDXYZ();
-    vector<int> nxyz=mesh->getCellGridStructure();
+    vector<int> nxyzMED=mesh->getCellGridStructure();
     double* Box0=new double[2*_dim];
     mesh->getBoundingBox(Box0);
-    _nxyz = nxyz;
-    for (int i=0; i<_dim; i++)
-    	_nxyz[i] = nxyz[i] + 1;
+    _nxyz = nxyzMED;
 
     _xMin=Box0[0];
     _xSup=Box0[1];
@@ -87,7 +85,7 @@ Mesh::Mesh( const ParaMEDMEM::MEDCouplingIMesh* mesh )
     for(int i=0;i<_dim;i++)
     {
         originPtr[i]=Box0[2*i];
-        nodeStrctPtr[i]=nxyz[i]+1;
+        nodeStrctPtr[i]=nxyzMED[i];
         dxyzPtr[i]=dxyz[i];
     }
 
@@ -516,12 +514,12 @@ Mesh::setMesh( void )
 Mesh::Mesh( double xinf, double xsup, int nx )
 //----------------------------------------------------------------------
 {
-	if(nx<=0)
-	    throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : nx <= 0");
-	if(xinf>=xsup)
-	    throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : xinf <= xsup");
+    if(nx<=0)
+        throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : nx <= 0");
+    if(xinf>=xsup)
+        throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : xinf <= xsup");
 
-	double dx = (xsup - xinf)/nx ;
+    double dx = (xsup - xinf)/nx ;
 
     _dim = 1 ;
     _xMin=xinf;
@@ -534,7 +532,7 @@ Mesh::Mesh( double xinf, double xsup, int nx )
     _dxyz.resize(_dim);
     _dxyz[0]=dx;
     _nxyz.resize(_dim);
-    _nxyz[0]=nx+1;
+    _nxyz[0]=nx;
 
     double *originPtr = new double[_dim];
     double *dxyzPtr = new double[_dim];
@@ -648,10 +646,10 @@ Mesh::Mesh( double xinf, double xsup, int nx )
 Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny)
 //----------------------------------------------------------------------
 {
-	if(nx<=0 || ny<=0)
-	    throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : nx <= 0 or ny <= 0");
-	if(xinf>=xsup || yinf>=ysup)
-	    throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : xinf <= xsup or yinf <= ysup");
+    if(nx<=0 || ny<=0)
+        throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : nx <= 0 or ny <= 0");
+    if(xinf>=xsup || yinf>=ysup)
+        throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : xinf <= xsup or yinf <= ysup");
     _xMin=xinf;
     _xSup=xsup;
     _yMin=yinf;
@@ -665,8 +663,8 @@ Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny)
 
     _dim = 2 ;
     _nxyz.resize(_dim);
-    _nxyz[0]=nx+1;
-    _nxyz[1]=ny+1;
+    _nxyz[0]=nx;
+    _nxyz[1]=ny;
 
     _dxyz.resize(_dim);
     _dxyz[0]=dx;
@@ -702,10 +700,10 @@ Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny)
 Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny, double zinf, double zsup, int nz)
 //----------------------------------------------------------------------
 {
-	if(nx<=0 || ny<=0 || nz<=0)
-	    throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : nx <= 0 or ny <= 0 or nz <= 0");
-	if(xinf>=xsup || yinf>=ysup)
-	    throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : xinf <= xsup or yinf <= ysup or zinf <= zsup");
+    if(nx<=0 || ny<=0 || nz<=0)
+        throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : nx <= 0 or ny <= 0 or nz <= 0");
+    if(xinf>=xsup || yinf>=ysup)
+        throw CdmathException("Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny) : xinf <= xsup or yinf <= ysup or zinf <= zsup");
     _dim=3;
     _xMin=xinf;
     _xSup=xsup;
@@ -724,9 +722,9 @@ Mesh::Mesh( double xinf, double xsup, int nx, double yinf, double ysup, int ny, 
     _dxyz[2]=dz;
 
     _nxyz.resize(_dim);
-    _nxyz[0]=nx+1;
-    _nxyz[1]=ny+1;
-    _nxyz[2]=nz+1;
+    _nxyz[0]=nx;
+    _nxyz[1]=ny;
+    _nxyz[2]=nz;
 
     double *originPtr = new double[_dim];
     double *dxyzPtr = new double[_dim];
@@ -782,7 +780,7 @@ int
 Mesh::getNx( void )  const
 //----------------------------------------------------------------------
 {
-    return _nxyz[0]-1 ;
+    return _nxyz[0];
 }
 
 //----------------------------------------------------------------------
@@ -792,7 +790,7 @@ Mesh::getNy( void )  const
 {
     if(_dim < 2)
         throw CdmathException("int double& Field::operator[ielem] : Ny is not defined in dimension < 2!");
-    return _nxyz[1]-1 ;
+    return _nxyz[1];
 }
 
 //----------------------------------------------------------------------
@@ -802,7 +800,7 @@ Mesh::getNz( void )  const
 {
     if(_dim < 3)
         throw CdmathException("int double& Field::operator[ielem] : Nz is not defined in dimension < 3!");
-    return _nxyz[2]-1 ;
+    return _nxyz[2];
 }
 
 //----------------------------------------------------------------------

--- a/mesh/src/Mesh.cxx
+++ b/mesh/src/Mesh.cxx
@@ -63,8 +63,10 @@ Mesh::Mesh( const ParaMEDMEM::MEDCouplingIMesh* mesh )
     double* Box0=new double[2*_dim];
     mesh->getBoundingBox(Box0);
     _nxyz = nxyzMED;
+    /*
     for (int i=0; i<_dim; i++)
 		_nxyz[i]--;
+	*/
 
     _xMin=Box0[0];
     _xSup=Box0[1];

--- a/tests/cdmath/MeshTests.cxx
+++ b/tests/cdmath/MeshTests.cxx
@@ -2,7 +2,7 @@
  * meshtests.cxx
  *
  *  Created on: 24 janv. 2012
- *      Authors: CDMAT
+ *      Authors: CDMATH
  */
 
 #include "MeshTests.hxx"
@@ -100,18 +100,6 @@ MeshTests::testClassMesh( void )
         if (y==0.5 && x==1.)
             CPPUNIT_ASSERT_EQUAL( -1, M2.getIndexFacePeriodic(i) );
     }
-    M2.writeMED("TestMesh");
-    Mesh M22("TestMesh.med");
-    CPPUNIT_ASSERT_EQUAL( 2, M22.getSpaceDimension() );
-    CPPUNIT_ASSERT_EQUAL( 25, M22.getNumberOfNodes() );
-    CPPUNIT_ASSERT_EQUAL( 16, M22.getNumberOfCells() );
-    CPPUNIT_ASSERT_EQUAL( 40, M22.getNumberOfFaces() );
-
-    Mesh M23("mesh.med");
-    CPPUNIT_ASSERT(M23.getNamesOfGroups()[0].compare("BORD1")==0);
-    CPPUNIT_ASSERT(M23.getNamesOfGroups()[1].compare("BORD2")==0);
-    CPPUNIT_ASSERT(M23.getNamesOfGroups()[2].compare("BORD3")==0);
-    CPPUNIT_ASSERT(M23.getNamesOfGroups()[3].compare("BORD4")==0);
 
     Mesh M3(M1);
     CPPUNIT_ASSERT_EQUAL( 1, M3.getSpaceDimension() );
@@ -135,13 +123,33 @@ MeshTests::testClassMesh( void )
     Mesh M5(0.0,1.0,4,0.0,1.0,4,0.0,1.0,4);
     CPPUNIT_ASSERT_EQUAL( 3, M5.getSpaceDimension() );
 
+
+    // Connection with MED
     string fileNameVTK="TestMesh";
-    M4.writeVTK(fileNameVTK) ;
     string fileNameMED="TestMesh";
-    M4.writeMED(fileNameMED) ;
-    Mesh M6(fileNameMED+".med");
+
+    M2.writeMED(fileNameMED);
+    Mesh M22(fileNameMED + ".med");
+    CPPUNIT_ASSERT_EQUAL( 2, M22.getSpaceDimension() );
+    CPPUNIT_ASSERT_EQUAL( 25, M22.getNumberOfNodes() );
+    CPPUNIT_ASSERT_EQUAL( 16, M22.getNumberOfCells() );
+    CPPUNIT_ASSERT_EQUAL( 40, M22.getNumberOfFaces() );
+
+    Mesh M23("mesh.med");
+    CPPUNIT_ASSERT(M23.getNamesOfGroups()[0].compare("BORD1")==0);
+    CPPUNIT_ASSERT(M23.getNamesOfGroups()[1].compare("BORD2")==0);
+    CPPUNIT_ASSERT(M23.getNamesOfGroups()[2].compare("BORD3")==0);
+    CPPUNIT_ASSERT(M23.getNamesOfGroups()[3].compare("BORD4")==0);
+
+    M4.writeVTK(fileNameVTK);
+    M4.writeMED(fileNameMED);
+    Mesh M6(fileNameMED + ".med");
     CPPUNIT_ASSERT_EQUAL( 2, M6.getSpaceDimension() );
     CPPUNIT_ASSERT_EQUAL( 25, M6.getNumberOfNodes() );
     CPPUNIT_ASSERT_EQUAL( 16, M6.getNumberOfCells() );
     CPPUNIT_ASSERT_EQUAL( 40, M6.getNumberOfFaces() );
+
+    /*
+    const MEDCouplingMesh* M1MEDMesh = M2.getMEDCouplingMesh();
+    */
 }

--- a/tests/cdmath/MeshTests.cxx
+++ b/tests/cdmath/MeshTests.cxx
@@ -22,6 +22,7 @@ void
 MeshTests::testClassMesh( void )
 //----------------------------------------------------------------------
 {
+    // Testing Mesh(xinf, xsup, nx)
     Mesh M1(0.0,4.0,4);
     CPPUNIT_ASSERT_EQUAL( 1, M1.getSpaceDimension() );
     CPPUNIT_ASSERT_EQUAL( 5, M1.getNumberOfNodes() );
@@ -52,6 +53,7 @@ MeshTests::testClassMesh( void )
     CPPUNIT_ASSERT(M1.getNamesOfGroups()[1].compare("RightEdge")==0);
 
 
+	// Testing Mesh(xinf, xsup, nx, yinf, ysup, ny)
     double xinf=0.0;
     double xsup=4.0;
     double yinf=0.0;
@@ -101,27 +103,31 @@ MeshTests::testClassMesh( void )
             CPPUNIT_ASSERT_EQUAL( -1, M2.getIndexFacePeriodic(i) );
     }
 
-    Mesh M3(M1);
-    CPPUNIT_ASSERT_EQUAL( 1, M3.getSpaceDimension() );
-    CPPUNIT_ASSERT_EQUAL( 5, M3.getNumberOfNodes() );
-    CPPUNIT_ASSERT_EQUAL( 4, M3.getNumberOfCells() );
-    CPPUNIT_ASSERT_EQUAL( 5, M3.getNumberOfFaces() );
 
-    M3=M2;
-    CPPUNIT_ASSERT_EQUAL( 2, M3.getSpaceDimension() );
-    CPPUNIT_ASSERT_EQUAL( 25, M3.getNumberOfNodes() );
-    CPPUNIT_ASSERT_EQUAL( 16, M3.getNumberOfCells() );
-    CPPUNIT_ASSERT_EQUAL( 40, M3.getNumberOfFaces() );
+	// Testing Mesh(xinf, xsup, nx, yinf, ysup, ny, zinf, zsup, nz)
+    Mesh M3(0.0,1.0,4,0.0,1.0,4,0.0,1.0,4);
+    CPPUNIT_ASSERT_EQUAL( 3, M3.getSpaceDimension() );
+    
+    
+    // Testing copies
+	Mesh Mcopy1(M1);
+    CPPUNIT_ASSERT_EQUAL( 1, Mcopy1.getSpaceDimension() );
+    CPPUNIT_ASSERT_EQUAL( 5, Mcopy1.getNumberOfNodes() );
+    CPPUNIT_ASSERT_EQUAL( 4, Mcopy1.getNumberOfCells() );
+    CPPUNIT_ASSERT_EQUAL( 5, Mcopy1.getNumberOfFaces() );
 
-    Mesh M4;
-    M4=M3;
-    CPPUNIT_ASSERT_EQUAL( 2, M4.getSpaceDimension() );
-    CPPUNIT_ASSERT_EQUAL( 25, M4.getNumberOfNodes() );
-    CPPUNIT_ASSERT_EQUAL( 16, M4.getNumberOfCells() );
-    CPPUNIT_ASSERT_EQUAL( 40, M4.getNumberOfFaces() );
+    Mcopy1=M2;
+    CPPUNIT_ASSERT_EQUAL( 2, Mcopy1.getSpaceDimension() );
+    CPPUNIT_ASSERT_EQUAL( 25, Mcopy1.getNumberOfNodes() );
+    CPPUNIT_ASSERT_EQUAL( 16, Mcopy1.getNumberOfCells() );
+    CPPUNIT_ASSERT_EQUAL( 40, Mcopy1.getNumberOfFaces() );
 
-    Mesh M5(0.0,1.0,4,0.0,1.0,4,0.0,1.0,4);
-    CPPUNIT_ASSERT_EQUAL( 3, M5.getSpaceDimension() );
+    Mesh Mcopy2;
+    Mcopy2=Mcopy1;
+    CPPUNIT_ASSERT_EQUAL( 2, Mcopy2.getSpaceDimension() );
+    CPPUNIT_ASSERT_EQUAL( 25, Mcopy2.getNumberOfNodes() );
+    CPPUNIT_ASSERT_EQUAL( 16, Mcopy2.getNumberOfCells() );
+    CPPUNIT_ASSERT_EQUAL( 40, Mcopy2.getNumberOfFaces() );
 
 
     // Connection with MED
@@ -141,8 +147,8 @@ MeshTests::testClassMesh( void )
     CPPUNIT_ASSERT(M23.getNamesOfGroups()[2].compare("BORD3")==0);
     CPPUNIT_ASSERT(M23.getNamesOfGroups()[3].compare("BORD4")==0);
 
-    M4.writeVTK(fileNameVTK);
-    M4.writeMED(fileNameMED);
+    Mcopy2.writeVTK(fileNameVTK);
+    Mcopy2.writeMED(fileNameMED);
     Mesh M6(fileNameMED + ".med");
     CPPUNIT_ASSERT_EQUAL( 2, M6.getSpaceDimension() );
     CPPUNIT_ASSERT_EQUAL( 25, M6.getNumberOfNodes() );


### PR DESCRIPTION
This commit fixes a bug in the relation between CDMATH meshes (Mesh) and MED Image meshes (IMesh). Now if you create a Mesh from an IMesh and/or if you extract an IMesh from a Mesh, the two objects have the same attribute .getNx() which returns the number of cells in the x direction. That makes much more sense. The same applies for the y and the z directions too.

Please check that it doesn't break your code, in particular if you use this relation between CDMATH and MED.